### PR TITLE
NEW Refactor to not require sake

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ it is a requirement of `silverstripe/graphql`.
 ## Configuration
 
 The plugin runs `sake dev/graphql/build` by default, which builds all schemas.
-Set an `SS_GRAPHQL_COMPOSER_CMD` environment constant in order to customise this.
+Set an `SS_GRAPHQL_COMPOSER_BUILD_SCHEMAS` environment constant in order to influence this behaviour.
 You can either limit this to a specific schema
 ([details](https://docs.silverstripe.org/en/4/developer_guides/graphql/getting_started/building_the_schema/)),
 or set it to an empty string to disable execution.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "composer-plugin-api": "^1.1 || ^2",
         "silverstripe/graphql": "^4",
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4.9 || 4.x-dev"
     },
     "require-dev": {
         "composer/composer": "^1.2 || 2"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require": {
         "composer-plugin-api": "^1.1 || ^2",
-        "silverstripe/graphql": "^4"
+        "silverstripe/graphql": "^4",
+        "silverstripe/framework": "^4"
     },
     "require-dev": {
         "composer/composer": "^1.2 || 2"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -24,6 +24,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     protected $io;
 
+    /**
+     * @var Composer
+     */
+    protected $composer;
+
     public static function getSubscribedEvents()
     {
         return array(
@@ -35,12 +40,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     public function activate(Composer $composer, IOInterface $io)
     {
         $this->io = $io;
-
-        // https://github.com/composer/composer/issues/5998
-        $vendorDir = $composer->getConfig()->get('vendor-dir');
-        require_once $vendorDir . '/autoload.php';
-        // Required for BASE_PATH
-        require_once $vendorDir . '/silverstripe/framework/src/includes/constants.php';
+        $this->composer = $composer;
     }
 
     public function deactivate(Composer $composer, IOInterface $io)
@@ -61,6 +61,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         if ($schemas === '') {
             return;
         }
+
+        // https://github.com/composer/composer/issues/5998
+        $vendorDir = $this->composer->getConfig()->get('vendor-dir');
+        require_once $vendorDir . '/autoload.php';
+        // Required for BASE_PATH
+        require_once $vendorDir . '/silverstripe/framework/src/includes/constants.php';
 
         // Throw an exception when any logic in this execution is attempting to perform a query.
         // GraphQL code generation can happen on environments which don't have a valid database connection,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -69,7 +69,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $this->io->write('<info>silverstripe/graphql-composer-plugin: Building schemas</info>');
 
             $keys = $schemas ? explode(',', $schemas) : array_keys(Schema::config()->get('schemas'));
-
             $keys = array_filter($keys, function ($key) {
                 return $key !== Schema::ALL;
             });

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace SilverStripe\GraphQLComposerPlugin;
 
 use Composer\Composer;
@@ -7,9 +6,13 @@ use Composer\Plugin\PluginInterface;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Script\Event;
 use Composer\IO\IOInterface;
+use SilverStripe\Core\CoreKernel;
+use SilverStripe\GraphQL\Schema\Exception\EmptySchemaException;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\GraphQL\Schema\SchemaBuilder;
-use SilverStripe\GraphQL\Schema\Storage\CodeGenerationStoreCreator;
+
+//require_once __DIR__ . '/../../../autoload.php';
+require_once __DIR__ . '/../../../silverstripe/framework/src/includes/constants.php';
 
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
@@ -44,21 +47,30 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
     public function generateSchema(Event $event)
     {
+        $schemas = getenv('SS_GRAPHQL_COMPOSER_BUILD_SCHEMAS');
+        // TODO Filter by schema
 
-        // vendor/bin is temorarily pushed on top of PATH, see https://getcomposer.org/doc/articles/scripts.md
-        $cmd = defined('SS_GRAPHQL_COMPOSER_CMD') ? SS_GRAPHQL_COMPOSER_CMD : 'sake dev/graphql/build';
+        // Not using sake because it creates a HTTPApplication through cli-script.php.
+        // This would trigger middlewares assuming a HTTP request execution
+        // (rather than CLI), which then connect to the database that might not be available during this build.
+        $kernel = new CoreKernel(BASE_PATH, false);
+        $kernel->boot();
 
-        // Allow disabling by null'ing the env var
-        if (!$cmd) {
-            return;
-        }
-
-        // title() and section() exist in symfony/console, but not through IOInterface
-        $this->io->write('<info>######################################################</info>');
         $this->io->write('<info>silverstripe/graphql-composer-plugin: Building schemas</info>');
-        $this->io->write('<info>######################################################</info>');
 
-        $out = shell_exec($cmd);
-        $this->io->write($out);
+        $keys = array_keys(Schema::config()->get('schemas'));
+        $keys = array_filter($keys, function ($key) {
+            return $key !== Schema::ALL;
+        });
+        foreach ($keys as $key) {
+            $builder = SchemaBuilder::singleton();
+            $schema = $builder->boot($key);
+            $this->io->write(sprintf('Building schema "%s"', $key));
+            try {
+                $builder->build($schema);
+            } catch (EmptySchemaException $e) {
+                $this->io->write('error');
+            }
+        }
     }
 }


### PR DESCRIPTION
There's no straightforward way to have sake run without a database connection.
When using a "fake" HTTPApplication for CLI execution, it executes middleware which rightfully assumes a database connection (e.g. fluent is getting available languages to modify routing).

Todo:

 * [x] Remove error handlers assuming HTTP context (e.g. SERVER_PROTOCOL)
 * [x] Test with composer v1
 * [ ] Test clean 4.x install
 * [ ] Test that it creates files in public/assets
 * [x] Fix reliance of error handling on `$_SERVER`

Relies on https://github.com/silverstripe/silverstripe-framework/pull/9977

Related:

 * [RFC: Avoid HTTPApplication for CLI](https://github.com/silverstripe/silverstripe-framework/issues/7509)
 * [RFC: Use Symfony Console for better CLI output](https://github.com/silverstripe/silverstripe-framework/issues/5542)